### PR TITLE
Fix/change locale

### DIFF
--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -76,17 +76,16 @@
 (defn ensure-locale-loaded!
   "Ensure that the given locale is loaded. Is a no-op if there are translations in app state for the given locale
   which is a keyword like :es-MX."
-  [app locale]
-  (let [state (app/current-state app)]
-    (when-not (is-locale-loaded? @state locale)
-      (df/load! app ::translations Locale {:params        {:locale locale}
-                                           :marker        false
-                                           :post-mutation `translations-loaded}))))
+  [app locale state]
+  (when-not (is-locale-loaded? @state locale)
+    (df/load! app ::translations Locale {:params        {:locale locale}
+                                         :marker        false
+                                         :post-mutation `translations-loaded})))
 (defmutation change-locale
   "Mutation: Change the locale. The parameter should be a locale ID, which is a keyword like :en or :es-MX."
   [{:keys [locale]}]
   (action [{:keys [state app]}]
-    (ensure-locale-loaded! app locale)
+    (ensure-locale-loaded! app locale state)
     (swap! state assoc ::current-locale (comp/get-ident Locale {::locale locale}))
     (app/force-root-render! app))
   (refresh [env]

--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -65,6 +65,7 @@
   (action [{:keys [state app]}]
     (swap! state dissoc ::translations)
     (when app
+      (app/update-shared! app)
       (app/force-root-render! app))))
 
 (defn is-locale-loaded?

--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -77,7 +77,7 @@
   "Ensure that the given locale is loaded. Is a no-op if there are translations in app state for the given locale
   which is a keyword like :es-MX."
   [app locale]
-  (let [state-map @(::app/state-atom app)]
+  (let [state-map (app/current-state app)]
     (when-not (is-locale-loaded? state-map locale)
       (df/load! app ::translations Locale {:params        {:locale locale}
                                            :marker        false

--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -50,7 +50,7 @@
                             nil))]
        (when translations
          {::locale       locale
-          ::translations (into {} (map (fn [t] [[(or (:msgctxt t) "") (:msgid t)] (:msgstr t)]) translations))}))))
+          ::translations (into {} (map (fn [t] [[(or (:msgctxt t) "") (:msgid t)] (:msgstr t)])) translations)}))))
 
 (defsc Locale
   "Represents the data of a locale in app state. Normalized by locale ID."

--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -76,16 +76,17 @@
 (defn ensure-locale-loaded!
   "Ensure that the given locale is loaded. Is a no-op if there are translations in app state for the given locale
   which is a keyword like :es-MX."
-  [app locale state]
-  (when-not (is-locale-loaded? @state locale)
-    (df/load! app ::translations Locale {:params        {:locale locale}
-                                         :marker        false
-                                         :post-mutation `translations-loaded})))
+  [app locale]
+  (let [state-map @(:com.fulcrologic.fulcro.application/state-atom app)]
+    (when-not (is-locale-loaded? state-map locale)
+      (df/load! app ::translations Locale {:params        {:locale locale}
+                                           :marker        false
+                                           :post-mutation `translations-loaded}))))
 (defmutation change-locale
   "Mutation: Change the locale. The parameter should be a locale ID, which is a keyword like :en or :es-MX."
   [{:keys [locale]}]
   (action [{:keys [state app]}]
-    (ensure-locale-loaded! app locale state)
+    (ensure-locale-loaded! app locale)
     (swap! state assoc ::current-locale (comp/get-ident Locale {::locale locale}))
     (app/force-root-render! app))
   (refresh [env]

--- a/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
+++ b/src/main/com/fulcrologic/fulcro_i18n/i18n.cljc
@@ -50,7 +50,7 @@
                             nil))]
        (when translations
          {::locale       locale
-          ::translations (into {} (map (fn [t] [[(or (:msgctxt t) "") (:msgid t)] (:msgstr t)])) translations)}))))
+          ::translations (into {} (map (fn [t] [[(or (:msgctxt t) "") (:msgid t)] (:msgstr t)]) translations))}))))
 
 (defsc Locale
   "Represents the data of a locale in app state. Normalized by locale ID."
@@ -77,7 +77,7 @@
   "Ensure that the given locale is loaded. Is a no-op if there are translations in app state for the given locale
   which is a keyword like :es-MX."
   [app locale]
-  (let [state-map @(:com.fulcrologic.fulcro.application/state-atom app)]
+  (let [state-map @(::app/state-atom app)]
     (when-not (is-locale-loaded? state-map locale)
       (df/load! app ::translations Locale {:params        {:locale locale}
                                            :marker        false
@@ -88,6 +88,7 @@
   (action [{:keys [state app]}]
     (ensure-locale-loaded! app locale)
     (swap! state assoc ::current-locale (comp/get-ident Locale {::locale locale}))
+    (app/update-shared! app)
     (app/force-root-render! app))
   (refresh [env]
     [::current-locale]))


### PR DESCRIPTION
Fixes the change-locale mutation.

- Uses already available state to avoid error
- Forces recalculation of shared props, making sure that the props that we need are available, before re-rendering root